### PR TITLE
[BI-5] support the choice of GPT models

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -650,7 +650,7 @@ function App(): JSX.Element {
                     style={{ backgroundColor: isDarkMode ? '#333' : '#fff', color: textColor }}
                   >
                     <option value="gpt-4o">gpt-4o</option>
-                    <option value="o1">o1</option>
+                    <option value="o1-preview">o1-preview</option>
                   </select>
                 </div>
               </div>

--- a/server/server.js
+++ b/server/server.js
@@ -36,7 +36,17 @@ Your solution must:
 
 const SUPPORTED_MODELS = {
   'gpt-4o': { max_tokens: 10000 },
-  'o1': { max_tokens: 10000 },
+  'o1-preview': { max_completion_tokens: 10000 },
+};
+
+const COST_PER_1K_PROMPT_TOKENS = {
+  'gpt-4o': 0.03,
+  'o1-preview': 0.001
+};
+
+const COST_PER_1K_COMPLETION_TOKENS = {
+  'gpt-4o': 0.06,
+  'o1-preview': 0.001
 };
 
 app.post('/api/ask', async (req, res) => {
@@ -51,12 +61,23 @@ app.post('/api/ask', async (req, res) => {
   }
 
   try {
+    console.log(`[OpenAI Request] Model: ${model}, question length: ${question.length}`);
     const content = pre_prompt + question;
     const response = await openai.chat.completions.create({
       model,
       messages: [{ role: "user", content: content }],
       max_tokens: SUPPORTED_MODELS[model].max_tokens
     });
+
+    const { usage } = response;
+    if (usage) {
+      console.log(`[OpenAI Response] Model: ${model}, Prompt: ${usage.prompt_tokens}, Completion: ${usage.completion_tokens}, Total: ${usage.total_tokens}`);
+
+      const promptCost = (usage.prompt_tokens / 1000) * COST_PER_1K_PROMPT_TOKENS[model];
+      const completionCost = (usage.completion_tokens / 1000) * COST_PER_1K_COMPLETION_TOKENS[model];
+      const totalCost = promptCost + completionCost;
+      console.log(`[OpenAI Cost] Model: ${model}, Prompt: $${promptCost.toFixed(4)}, Completion: $${completionCost.toFixed(4)}, Total: $${totalCost.toFixed(4)}`);
+    }
 
     const answer = response.choices[0].message.content.trim();
     res.json({ answer });


### PR DESCRIPTION
This pull request includes changes to the `client/src/App.tsx` and `server/server.js` files to support multiple AI models. The most important changes include adding a model selection feature in the client application and handling different models on the server side.

### Client-side changes:

* [`client/src/App.tsx`](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L58-R66): Added a new state variable `model` to store the selected AI model and updated the `askChatGPT` function to include the model in the request payload. [[1]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L58-R66) [[2]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337R126) [[3]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L205-R207)
* [`client/src/App.tsx`](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337R645-R655): Added a dropdown menu to allow users to select between different models (`gpt-4o` and `o1-preview`).

### Server-side changes:

* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938R37-R81): Introduced constants `SUPPORTED_MODELS`, `COST_PER_1K_PROMPT_TOKENS`, and `COST_PER_1K_COMPLETION_TOKENS` to define supported models and their respective costs.
* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938R37-R81): Updated the `/api/ask` endpoint to accept a model parameter, validate the selected model, and log the cost of the request based on the model used.