### PR TITLE
[STYLE-3] improve 'settings' experience and persist the auth state when refreshing the page.

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,9 +18,9 @@ interface DecodedToken {
 // Helper function type definitions
 const handleGoogleAuthToken = (credential: string): boolean => {
   try {
-    const decoded: DecodedToken = jwtDecode<DecodedToken>(credential);
+    const decoded = jwtDecode<DecodedToken>(credential);
     if (decoded?.exp && decoded.exp * 1000 > Date.now()) {
-      document.cookie = `authToken=${credential}; Secure; HttpOnly; SameSite=Strict; Max-Age=21600`;
+      document.cookie = `authToken=${credential}; path=/; Secure; SameSite=Strict; Max-Age=21600`;
       return true;
     }
   } catch (err) {
@@ -144,7 +144,7 @@ function App(): JSX.Element {
     const cookieMatch = document.cookie.match(/^(.*;)?\s*authToken\s*=\s*([^;]+)(.*)?$/);
     if (cookieMatch) {
       const token = cookieMatch[2];
-      const decoded: any = jwtDecode(token);
+      const decoded = jwtDecode<DecodedToken>(token);
       if (decoded?.exp && decoded.exp * 1000 > Date.now()) {
         setIsAuthenticated(true);
       }


### PR DESCRIPTION
This pull request includes several changes to the `client/src/App.tsx` file to improve the handling of authentication tokens and add a new feature for closing the settings menu when clicking outside of it. The most important changes include updating the `DecodedToken` type usage, adding a ref for the settings container, and implementing the click outside handler for the settings menu.

Improvements to token handling:

* Updated the `DecodedToken` type usage in `handleGoogleAuthToken` and `App` function to ensure proper type inference. [[1]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L21-R23) [[2]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L146-R147)
* Modified the `document.cookie` assignment in `handleGoogleAuthToken` to include the `path=/` attribute for better cookie management.

New feature for settings menu:

* Added a `settingsContainerRef` to the `App` component to reference the settings container div. [[1]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337R116) [[2]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L602-R619)
* Implemented a `useEffect` hook to handle clicks outside the settings menu, which closes the menu when clicking outside of it.